### PR TITLE
Fix deprecated call

### DIFF
--- a/parser.y
+++ b/parser.y
@@ -29,7 +29,7 @@
 %skeleton "lalr1.cc" /* -*- C++ -*- */
 %require "3.0"
 %defines
-%define parser_class_name { Parser }
+%define api.parser.class { Parser }
 
 %define api.token.constructor
 %define api.value.type variant


### PR DESCRIPTION
This fixes a deprecation I was seeing with Bison `3.4.1`, the current version that ships in Ubuntu

```
parser.y:32.1-36: warning: deprecated directive, use ‘%define api.parser.class { Parser }’ [-Wdeprecated]
   32 | %define parser_class_name { Parser }
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
parser.y: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
```